### PR TITLE
Fixed Timer not returning correct time on resume.

### DIFF
--- a/lib/Timer/Timer.test.js
+++ b/lib/Timer/Timer.test.js
@@ -37,6 +37,19 @@ describe('Timer', () => {
       timer.startTimer()
       expect(timer.startTimer()).toBe(false)
     })
+
+    it('Should continue from the original start time if the timer is stopped and then started again', () => {
+      const timer = new Timer()
+
+      timer.startTimer()
+      jest.advanceTimersByTime(1000)
+      timer.stopTimer()
+      jest.advanceTimersByTime(1000)
+      timer.startTimer()
+      jest.advanceTimersByTime(1000)
+
+      expect(timer.getElapsedTime()).toBe(2000)
+    })
   })
 
   describe('stopTimer', () => {

--- a/lib/Timer/index.js
+++ b/lib/Timer/index.js
@@ -8,7 +8,13 @@ class Timer {
       return false
     }
 
-    this.startTime = Date.now()
+    if (this.endTime) {
+      this.startTime = Date.now() - this.getElapsedTime()
+    } else {
+      this.startTime = Date.now()
+    }
+    this.endTime = undefined
+
     clearInterval(this.intervalId)
     this.intervalId = setInterval(this.onTimerTick.bind(this), 100)
 


### PR DESCRIPTION
Calling `startTimer`, `stopTimer` and then `startTimer`  again on a `Timer` object as demonstrated by the newly added test should "resume" the timer and `getElapsedTime` should return the time passed only while the timer was "active".

There are two issues with the current implementation that prevent that:
 1. The `startTime` field is not updated when calling `startTimer` again after stopping a timer.
 2. The `endTime` field is not reset when calling `startTimer` again after stopping a timer.